### PR TITLE
Update manifest.yml env: java11

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -5,3 +5,5 @@ applications:
     path: target/equipmeneger-0.0.1-SNAPSHOT.jar
     memory: 2000M
     instances: 1
+    env:
+      JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 11.+ } }'


### PR DESCRIPTION
#31 での java8 から java11 への変更に、IBM cloud 側が対応するための変更

reference: https://www.project-respite.com/cloudfoundry-java11/